### PR TITLE
Support Date Time concatenation and other improvements

### DIFF
--- a/InstantConcatenateExternalModule.php
+++ b/InstantConcatenateExternalModule.php
@@ -5,11 +5,11 @@ use ExternalModules\ExternalModules;
 
 class InstantConcatenateExternalModule extends AbstractExternalModule
 {
-	function hook_data_entry_form($project_id, $record, $instrument, $event_id, $group_id) {
+	function redcap_data_entry_form($project_id, $record, $instrument, $event_id, $group_id) {
 		$this->concatenate($project_id, $record, $instrument, $event_id, $group_id);
 	}
 
-	function hook_survey_page($project_id, $record, $instrument, $event_id, $group_id, $survey_hash, $response_id) {
+	function redcap_survey_page($project_id, $record, $instrument, $event_id, $group_id, $survey_hash, $response_id) {
 		$this->concatenate($project_id, $record, $instrument, $event_id, $group_id);
 	}
 
@@ -50,7 +50,7 @@ class InstantConcatenateExternalModule extends AbstractExternalModule
 								destination.change();
 							}";
 					foreach ($srcFields as $src) {
-						echo "$('[name=\"" . $src . "\"]').change(function() { concat(); }); ";
+						echo "$('[name=\"" . $src . "\"]').blur(function() { concat(); }); ";
 					}
 					echo " });\n";
 					echo "</script>";

--- a/config.json
+++ b/config.json
@@ -5,6 +5,8 @@
 
 	"description": "This module concatenates fields and places the result in another field instantly. It uses JavaScript and not PHP. It happens upon the user leaving the field.",
 
+	"framework-version": 12,
+
 	"authors": [
 		{
 			"name": "Scott J. Pearson",
@@ -13,12 +15,15 @@
 		}
 	],
 	
-	"permissions": [
-                "hook_survey_page",
-                "hook_data_entry_form"
-	],
-
 	"links": {
+		"project": [
+            {
+                "name": "Concatenate Fields in All records",
+                "icon": "fa fa-tasks",
+                "url": "process-all-records.php",
+                "show-header-and-footer": true
+            }
+        ]
 	},
 
 	"project-settings": [


### PR DESCRIPTION
1.  'change' to 'blur' to fix the issue date change with Today button not responded.
2. modified procee-all-records.php to a) considering date validation type when concatenating date time fields b) user can choose save or not save concatenation from the page
3. added link 'Concatenate Fields in All records' for easy access to procee-all-records.php
4. set framework version to 12 and made necessary changes to adapt to this version (in order to show fontawesome icon for the link).